### PR TITLE
Resolves #3

### DIFF
--- a/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/MessageTest.cs
+++ b/src/Application/tests/RazorPagesTestSample.Tests/UnitTests/MessageTest.cs
@@ -1,0 +1,119 @@
+using System.ComponentModel.DataAnnotations;
+using Xunit;
+
+namespace RazorPagesTestSample.Data.Tests
+{
+    public class MessageTest
+    {
+        [Fact]
+        public void Message_Id_ShouldGetAndSetId()
+        {
+            // Arrange
+            var message = new Message();
+            var expectedId = 1;
+
+            // Act
+            message.Id = expectedId;
+
+            // Assert
+            Assert.Equal(expectedId, message.Id);
+        }
+
+        [Fact]
+        public void Message_Text_ShouldGetAndSetText()
+        {
+            // Arrange
+            var message = new Message();
+            var expectedText = "Hello, World!";
+
+            // Act
+            message.Text = expectedText;
+
+            // Assert
+            Assert.Equal(expectedText, message.Text);
+        }
+
+        [Fact]
+        public void Message_Text_ShouldHaveRequiredAttribute()
+        {
+            // Arrange
+            var property = typeof(Message).GetProperty(nameof(Message.Text));
+
+            // Act
+            var attribute = property.GetCustomAttributes(typeof(RequiredAttribute), false);
+
+            // Assert
+            Assert.NotEmpty(attribute);
+        }
+
+        [Fact]
+        public void Message_Text_ShouldHaveStringLengthAttribute()
+        {
+            // Arrange
+            var property = typeof(Message).GetProperty(nameof(Message.Text));
+
+            // Act
+            var attribute = property.GetCustomAttributes(typeof(StringLengthAttribute), false).FirstOrDefault() as StringLengthAttribute;
+
+            // Assert
+            Assert.NotNull(attribute);
+            Assert.Equal(250, attribute.MaximumLength);
+        }
+
+        [Fact]
+        public void Message_Text_ShouldHaveDataTypeAttribute()
+        {
+            // Arrange
+            var property = typeof(Message).GetProperty(nameof(Message.Text));
+
+            // Act
+            var attribute = property.GetCustomAttributes(typeof(DataTypeAttribute), false).FirstOrDefault() as DataTypeAttribute;
+
+            // Assert
+            Assert.NotNull(attribute);
+            Assert.Equal(DataType.Text, attribute.DataType);
+        }
+        
+        [Fact]
+                public void Message_Text_ShouldAllowTextWithLength200()
+                {
+                    // Arrange
+                    var message = new Message();
+                    var text = new string('a', 200);
+
+                    // Act
+                    message.Text = text;
+
+                    // Assert
+                    Assert.Equal(text, message.Text);
+                }
+
+                [Fact]
+                public void Message_Text_ShouldAllowTextWithLength250()
+                {
+                    // Arrange
+                    var message = new Message();
+                    var text = new string('a', 250);
+
+                    // Act
+                    message.Text = text;
+
+                    // Assert
+                    Assert.Equal(text, message.Text);
+                }
+
+                [Fact]
+                public void Message_Text_ShouldNotAllowTextWithLength300()
+                {
+                    // Arrange
+                    var message = new Message();
+                    var text = new string('a', 300);
+
+                    // Act & Assert
+                    var exception = Assert.Throws<ValidationException>(() => Validator.ValidateObject(message, new ValidationContext(message), true));
+                    Assert.Contains("There's a 250 character limit on messages. Please shorten your message.", exception.Message);
+                }
+        
+    }
+}
+


### PR DESCRIPTION
This pull request introduces unit tests for the `Message` class in the `RazorPagesTestSample` project. The tests cover various aspects of the `Message` class, including property getters and setters, attribute presence, and validation rules.

### Unit Tests for `Message` Class:

* [`MessageTest.cs`](diffhunk://#diff-7f4bca3060b66cab1a947141ca7af1e6cee4d379679fc6c4df6337e26f45e3ddR1-R119): Added tests to verify the `Id` and `Text` properties' getter and setter functionality.
* [`MessageTest.cs`](diffhunk://#diff-7f4bca3060b66cab1a947141ca7af1e6cee4d379679fc6c4df6337e26f45e3ddR1-R119): Added tests to check for the presence of `Required`, `StringLength`, and `DataType` attributes on the `Text` property.
* [`MessageTest.cs`](diffhunk://#diff-7f4bca3060b66cab1a947141ca7af1e6cee4d379679fc6c4df6337e26f45e3ddR1-R119): Added validation tests to ensure the `Text` property adheres to the specified length constraints (200, 250, and 300 characters).